### PR TITLE
add proto file and java files to consume dsp event to kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -405,6 +405,13 @@
     </dependencies>
 
     <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.6.0</version>
+            </extension>
+        </extensions>
         <resources>
             <resource>
                 <directory>src/main/config</directory>
@@ -622,6 +629,27 @@
                 <configuration>
                     <useSystemClassLoader>false</useSystemClassLoader>
                 	<forkCount>1.5C</forkCount>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <additionalProtoPathElements>
+                        <!--Actually default path is src/main/proto/, you may add extra paths here -->
+                        <additionalProtoPathElement>${project.basedir}/src/main/proto</additionalProtoPathElement>
+                    </additionalProtoPathElements>
+                    <protocArtifact>com.google.protobuf:protoc:3.18.2:exe:${os.detected.classifier}</protocArtifact>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -234,7 +234,7 @@ kafka.fetch.max.bytes=
 kafka.fetch.wait.max.ms=
 
 # Port of the broker serving topic partition metadata.
-kafka.seed.broker.port=9092
+kafka.seed.broker.port=29092
 
 # Zookeeper path at which kafka is registered. In Zookeeper parlance, this is referred
 # to as the chroot.
@@ -415,7 +415,7 @@ secor.compression.codec=
 secor.file.extension=
 
 # The secor file reader/writer used to read/write the data, by default we write sequence files
-secor.file.reader.writer.factory=com.pinterest.secor.io.impl.SequenceFileReaderWriterFactory
+secor.file.reader.writer.factory=com.pinterest.secor.io.impl.ProtobufParquetFileReaderWriterFactory
 #if left blank defaults to \n
 secor.file.reader.Delimiter=\n
 #if left blank no Delimiter is added. do not use \ as that needs to be escaped and is an escape

--- a/src/main/config/secor.dev.hr.partition.properties
+++ b/src/main/config/secor.dev.hr.partition.properties
@@ -1,7 +1,7 @@
 include=secor.dev.properties
 
 secor.kafka.group=secor_hr_partition
-secor.message.parser.class=com.pinterest.secor.parser.ThriftMessageParser
+secor.message.parser.class=com.pinterest.secor.parser.JsonMessageParser
 
 secor.s3.path=secor_dev/hr_partition
 secor.local.path=/tmp/secor_dev/message_logs/hr_partition

--- a/src/main/config/secor.dev.partition.properties
+++ b/src/main/config/secor.dev.partition.properties
@@ -19,7 +19,7 @@ include=secor.dev.properties
 secor.kafka.group=secor_partition
 
 # Parser class that extracts s3 partitions from consumed messages.
-secor.message.parser.class=com.pinterest.secor.parser.ThriftMessageParser
+secor.message.parser.class=com.pinterest.secor.parser.JsonMessageParser
 
 # S3 path where sequence files are stored.
 secor.s3.path=secor_dev/partition

--- a/src/main/config/secor.dev.properties
+++ b/src/main/config/secor.dev.properties
@@ -28,10 +28,10 @@ secor.swift.container=logsContainer
 # END MUST SET #
 ################
 
-kafka.seed.broker.host=kafka
-kafka.seed.broker.port=9092
+kafka.seed.broker.host=localhost
+kafka.seed.broker.port=29092
 
-zookeeper.quorum=localhost:2181
+zookeeper.quorum=localhost:22181
 
 # Upload policies.
 # 10K
@@ -39,3 +39,9 @@ secor.max.file.size.bytes=10000
 # 10 seconds
 secor.max.file.age.seconds=10
 
+secor.protobuf.message.class.dsp-bids=com.pinterest.secor.proto.DspEvent
+secor.topic.message.format.dsp-bids=JSON
+
+secor.oci.namespace=idjztyxyzkqx
+secor.oci.bucket=dsp-events-test
+secor.oci.path=dsp

--- a/src/main/proto/dsp.proto
+++ b/src/main/proto/dsp.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+//package dsp;
+
+option java_multiple_files = true;
+option java_package = "com.pinterest.secor.proto";
+//option java_outer_classname = "DspProtos";
+
+message DspEvent {
+  optional string timestamp = 1;
+  optional string event_id = 2;
+  optional google.protobuf.Timestamp bid_timestamp = 3; // datetime
+  optional string device_id = 4;
+  optional string advertiser_id = 5;
+  optional string campaign_id = 6;
+  optional string creative_id = 7;
+  optional string publisher_id = 8;
+  optional string impression_id = 9;
+  optional string currency = 10;
+  optional double spend = 11; //Decimal64(8)
+  optional int32 views = 12;  // int32
+  optional int32 clicks = 13; // int32
+  optional int32 installs = 14; //Int32
+}


### PR DESCRIPTION
1. Let secor ingest json and write protobuf parquet to oracle cloud object storage. 
2. Add maven plugins to auto generate java code from .proto files.
Note: prod.properties not changed yet.

How to test. 
1 .Start Kafka and zookeeper at localhost:29092 and localhost:22181 respectively.

java -ea -Dsecor_group=secor_partition \
  -Dlog4j.configuration=log4j.dev.properties \
  -Dconfig=secor.dev.partition.properties \
  -cp "secor-0.30-SNAPSHOT.jar:lib/*" \
  com.pinterest.secor.main.ConsumerMain

Send a json message to kafka, like 
{"timestamp":"1710744835","event_id":"123456","bid_timestamp":"2017-01-15T01:30:15.01Z","device_id":"iphone-abc123","advertiser_id":"adv123","campaign_id":"campaign123","creative_id":"creative_234","publisher_id":"pub_456","impression_id":"imp_789","currency":"USD","spend":"45.789","views":"999","clicks":"888","installs":"777"}

We should get a file from Oracle clould. Download it and read in pandas. It should be like 

>>> df=pd.read_parquet('~/Downloads/dsp_dsp-bids_dt=2024-03-18_hr=06_1_0_00000000000000000037', engine='fastparquet')
>>> df
    
   timestamp event_id      device_id advertiser_id  campaign_id  \
0  1710744835   123456  iphone-abc123        adv123  campaign123

   creative_id publisher_id impression_id currency   spend  views  clicks  \
0  creative_234      pub_456       imp_789      USD  45.789    999     888

   installs  bid_timestamp.seconds  bid_timestamp.nanos
0       777             1484443815             10000000